### PR TITLE
Replaced the direct downloading with file streaming.

### DIFF
--- a/pixel_puzzle_web/app.py
+++ b/pixel_puzzle_web/app.py
@@ -16,9 +16,9 @@ from base64 import b64decode, b64encode
 from pathlib import Path
 from typing import Union
 
-import flask
 import numpy as np
-from flask import Flask, render_template, request, send_file
+from flask import (Flask, Response, make_response, render_template, request,
+                   send_file)
 from PIL import Image
 
 app = Flask(__name__)
@@ -138,7 +138,7 @@ def index() -> str:
 
 
 @app.route("/encode", methods=["POST"])
-def encode() -> flask.Response:
+def encode() -> Response:
     """
     __doc__
     """
@@ -146,11 +146,13 @@ def encode() -> flask.Response:
     encoded_text = "encoded.txt"
     image_to_encode.save(image_to_encode.filename)
     encode_base64(image_to_encode.filename, encoded_text)
-    return send_file(encoded_text, as_attachment=True)
+    response = make_response(send_file(encoded_text))
+    response.headers["Content-Disposition"] = "inline; filename=encoded.txt"
+    return response
 
 
 @app.route("/decode", methods=["POST"])
-def decode() -> flask.Response:
+def decode() -> Response:
     """
     __doc__
     """
@@ -158,11 +160,13 @@ def decode() -> flask.Response:
     decoded_image = "decoded.png"
     encoded_text.save(encoded_text.filename)
     decode_base64(encoded_text.filename, decoded_image)
-    return send_file(decoded_image, as_attachment=True)
+    response = make_response(send_file(decoded_image))
+    response.headers["Content-Disposition"] = "inline; filename=decoded.png"
+    return response
 
 
 @app.route("/shuffle", methods=["POST"])
-def shuffle() -> flask.Response:
+def shuffle() -> Response:
     """
     __doc__
     """
@@ -174,11 +178,13 @@ def shuffle() -> flask.Response:
     image_quality = request.form.get("image_quality")
     origin_image.save(origin_image.filename)
     shuffle_pixels(origin_image.filename, shuffled_image, seed, index_file, image_quality)
-    return send_file(shuffled_image, as_attachment=True)
+    response = make_response(send_file(shuffled_image))
+    response.headers["Content-Disposition"] = "inline; filename=shuffled.png"
+    return response
 
 
 @app.route("/recover", methods=["POST"])
-def recover() -> flask.Response:
+def recover() -> Response:
     """
     __doc__
     """
@@ -190,7 +196,9 @@ def recover() -> flask.Response:
     image_quality = request.form.get("image_quality")
     shuffled_image.save(shuffled_image.filename)
     recover_pixels(shuffled_image.filename, recovered_image, seed, index_file, image_quality)
-    return send_file(recovered_image, as_attachment=True)
+    response = make_response(send_file(recovered_image))
+    response.headers["Content-Disposition"] = "inline; filename=recovered.png"
+    return response
 
 
 if __name__ == "__main__":

--- a/pixel_puzzle_web/templates/index.html
+++ b/pixel_puzzle_web/templates/index.html
@@ -2,45 +2,94 @@
 <html lang="en">
 
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>Pixel Puzzle</title>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Pixel Puzzle</title>
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/material-design-lite/1.3.0/material.min.css">
+  <style>
+    body {
+      font-family: 'Roboto', sans-serif;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      justify-content: center;
+      height: 100vh;
+      background-color: #f5f5f5;
+    }
+
+    h1 {
+      color: #3f51b5;
+    }
+
+    form {
+      background: white;
+      padding: 20px;
+      margin: 10px;
+      border-radius: 8px;
+      box-shadow: 0 2px 4px rgba(0, 0, 0, 0.1);
+      width: 300px;
+    }
+
+    button {
+      background-color: #3f51b5;
+      color: white;
+      border: none;
+      padding: 10px 20px;
+      border-radius: 4px;
+      cursor: pointer;
+    }
+
+    button:hover {
+      background-color: #303f9f;
+    }
+
+    input[type="file"] {
+      margin-bottom: 10px;
+    }
+
+    select {
+      margin-bottom: 10px;
+    }
+  </style>
 </head>
 
 <body>
-    <h1>Pixel Puzzle</h1>
-    <form action="/encode" method="post" enctype="multipart/form-data">
-        <h2>Encode Image</h2>
-        <input type="file" name="image_to_encode" required>
-        <button type="submit">Encode</button>
-    </form>
-    <form action="/decode" method="post" enctype="multipart/form-data">
-        <h2>Decode Image</h2>
-        <input type="file" name="encoded_text" required>
-        <button type="submit">Decode</button>
-    </form>
-    <form action="/shuffle" method="post" enctype="multipart/form-data">
-        <h2>Shuffle Pixels</h2>
-        <input type="file" name="origin_image" required>
-        <input type="text" name="seed" placeholder="Seed (type 'no' for None)">
-        <select name="image_quality" required>
-            <option value="low">Low</option>
-            <option value="medium">Medium</option>
-            <option value="high">High</option>
-        </select>
-        <button type="submit">Shuffle</button>
-    </form>
-    <form action="/recover" method="post" enctype="multipart/form-data">
-        <h2>Recover Pixels</h2>
-        <input type="file" name="shuffled_image" required>
-        <input type="text" name="seed" placeholder="Seed (type 'no' for None)">
-        <select name="image_quality" required>
-            <option value="low">Low</option>
-            <option value="medium">Medium</option>
-            <option value="high">High</option>
-        </select>
-        <button type="submit">Recover</button>
-    </form>
+  <h1>Pixel Puzzle</h1>
+  <form action="/encode" method="post" enctype="multipart/form-data">
+    <h2>Encode Image</h2>
+    <input type="file" name="image_to_encode" required>
+    <button type="submit">Encode</button>
+  </form>
+  <form action="/decode" method="post" enctype="multipart/form-data">
+    <h2>Decode Image</h2>
+    <input type="file" name="encoded_text" required>
+    <button type="submit">Decode</button>
+  </form>
+  <form action="/shuffle" method="post" enctype="multipart/form-data">
+    <h2>Shuffle Pixels</h2>
+    <input type="file" name="origin_image" required>
+    <input type="text" name="seed" placeholder="Seed (type 'no' for None)">
+    <select name="image_quality" required>
+      <option value="low">Low</option>
+      <option value="medium">Medium</option>
+      <option value="high">High</option>
+    </select>
+    <button type="submit">Shuffle</button>
+  </form>
+  <form action="/recover" method="post" enctype="multipart/form-data">
+    <h2>Recover Pixels</h2>
+    <input type="file" name="shuffled_image" required>
+    <input type="text" name="seed" placeholder="Seed (type 'no' for None)">
+    <select name="image_quality" required>
+      <option value="low">Low</option>
+      <option value="medium">Medium</option>
+      <option value="high">High</option>
+    </select>
+    <button type="submit">Recover</button>
+  </form>
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/material-design-lite/1.3.0/material.min.js"></script>
 </body>
 
 </html>


### PR DESCRIPTION
- Use `response.headers["Content-Disposition"] = "inline; filename=file_name.suffix"` to stream files rather than download them for browser-supported formats.